### PR TITLE
Add the imagej-plugins-commands dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
 			<artifactId>imagej</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-plugins-commands</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
 		</dependency>


### PR DESCRIPTION
The ShowLUT command is used directly, therefore we must list the
dependency explicitly, too.

Thanks, Juryanna Jenkins!

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
