### PR TITLE
Better handling of mean lifetime values

### DIFF
--- a/src/main/java/loci/slim/SLIMProcessor.java
+++ b/src/main/java/loci/slim/SLIMProcessor.java
@@ -262,6 +262,7 @@ public class SLIMProcessor<T extends RealType<T>> {
 	public static final String SET_T3_FIX = "fixT3";
 
 	public static final String SET_H_FIX = "fixH";
+	
 
 	public static FitInfo fitInfo = new FitInfo();
 
@@ -3724,7 +3725,8 @@ public class SLIMProcessor<T extends RealType<T>> {
 		if (index == 3) {
 			UserInterfacePanel._hFix4.setSelected(state);
 		}
-
 	}
+	
+
 
 }

--- a/src/main/java/loci/slim/analysis/HistogramStatistics.java
+++ b/src/main/java/loci/slim/analysis/HistogramStatistics.java
@@ -23,11 +23,15 @@
 
 package loci.slim.analysis;
 
+import ij.IJ;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+
+import loci.slim.SLIMProcessor;
 
 /**
  * A histogram statistics class used for export to text.
@@ -259,50 +263,59 @@ public class HistogramStatistics {
 			// don't process any more parameters; all will have same count
 			return false;
 		}
-		writer.write("Parameter" + separator + getTitle());
-		writer.newLine();
 
-		// put out statistics
-		writer.write("Min" + separator + showParameter(getMin()));
-		writer.newLine();
-		writer.write("Max" + separator + showParameter(getMax()));
-		writer.newLine();
-		writer.write("Count" + separator + getCount());
-		writer.newLine();
-		writer.write("Mean" + separator + showParameter(getMean()));
-		writer.newLine();
-		writer.write("Standard Deviation" + separator +
-			showParameter(getStandardDeviation()));
-		writer.newLine();
-		writer
+		if(SLIMProcessor.macroParams.useDetailStat){
+			///add check for either all statisctics or just mean
+			//if(meanValueOnly){}else{}
+			writer.write("Parameter" + separator + getTitle());
+			writer.newLine();
+
+			// put out statistics
+			writer.write("Min" + separator + showParameter(getMin()));
+			writer.newLine();
+			writer.write("Max" + separator + showParameter(getMax()));
+			writer.newLine();
+			writer.write("Count" + separator + getCount());
+			writer.newLine();
+			writer.write("Mean" + separator + showParameter(getMean()));
+			writer.newLine();
+			writer.write("Standard Deviation" + separator +
+					showParameter(getStandardDeviation()));
+			writer.newLine();
+			writer
 			.write("1st Quartile" + separator + showParameter(getFirstQuartile()));
-		writer.newLine();
-		writer.write("Median" + separator + showParameter(getMedian()));
-		writer.newLine();
-		writer
+			writer.newLine();
+			writer.write("Median" + separator + showParameter(getMedian()));
+			writer.newLine();
+			writer
 			.write("3rd Quartile" + separator + showParameter(getThirdQuartile()));
-		writer.newLine();
+			writer.newLine();
 
-		// put out histogram
-		final long[] histo = getHistogram();
-		writer.write("Histogram");
-		writer.newLine();
-		writer.write("Bins" + separator + histo.length);
-		writer.newLine();
-		writer.write("Min" + separator + showParameter(getMinRange()));
-		writer.newLine();
-		writer.write("Max" + separator + showParameter(getMaxRange()));
-		writer.newLine();
-		writer.write("Count" + separator + getHistogramCount());
-		writer.newLine();
+			// put out histogram
+			final long[] histo = getHistogram();
+			writer.write("Histogram");
+			writer.newLine();
+			writer.write("Bins" + separator + histo.length);
+			writer.newLine();
+			writer.write("Min" + separator + showParameter(getMinRange()));
+			writer.newLine();
+			writer.write("Max" + separator + showParameter(getMaxRange()));
+			writer.newLine();
+			writer.write("Count" + separator + getHistogramCount());
+			writer.newLine();
 
-		final double[] values =
-			Binning.centerValuesPerBin(histo.length, getMinRange(), getMaxRange());
-		for (int j = 0; j < histo.length; ++j) {
-			writer.write(showParameter(values[j]) + separator + histo[j]);
+			final double[] values =
+					Binning.centerValuesPerBin(histo.length, getMinRange(), getMaxRange());
+			for (int j = 0; j < histo.length; ++j) {
+				writer.write(showParameter(values[j]) + separator + histo[j]);
+				writer.newLine();
+			}
 			writer.newLine();
 		}
-		writer.newLine();
+		else{
+			writer.write("Mean" + separator + showParameter(getMean()));
+			writer.newLine();
+		}
 		return true;
 	}
 
@@ -330,176 +343,238 @@ public class HistogramStatistics {
 			// don't process any more parameters; all will have same count
 			return false;
 		}
-
 		boolean firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Parameter" + separator + statistic.getTitle());
-		}
-		writer.newLine();
 
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Min" + separator + showParameter(statistic.getMin()));
-		}
-		writer.newLine();
 
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Max" + separator + showParameter(statistic.getMax()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Count" + separator + statistic.getCount());
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Mean" + separator + showParameter(statistic.getMean()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Standard Deviation" + separator +
-				showParameter(statistic.getStandardDeviation()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("1st Quartile" + separator +
-				showParameter(statistic.getFirstQuartile()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Median" + separator + showParameter(statistic.getMedian()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("3rd Quartile" + separator +
-				showParameter(statistic.getThirdQuartile()));
-		}
-		writer.newLine();
-
-		// get all of the histograms into memory
-		int maxHistosLength = Integer.MIN_VALUE;
-		final long[][] histos = new long[statistics.length][];
-		final double[][] centers = new double[statistics.length][];
-		for (int i = 0; i < statistics.length; ++i) {
-			histos[i] = statistics[i].getHistogram();
-			if (histos[i].length > maxHistosLength) {
-				maxHistosLength = histos[i].length;
-			}
-			centers[i] =
-				Binning.centerValuesPerBin(histos[i].length, statistics[i]
-					.getMinRange(), statistics[i].getMaxRange());
-		}
-
-		firstTime = true;
-		for (final long[] histo : histos) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Histogram Bins" + separator + histo.length);
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Histogram Min" + separator +
-				showParameter(statistic.getMinRange()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Histogram Max" + separator +
-				showParameter(statistic.getMaxRange()));
-		}
-		writer.newLine();
-
-		firstTime = true;
-		for (final HistogramStatistics statistic : statistics) {
-			if (!firstTime) {
-				writer.write(separator);
-			}
-			firstTime = false;
-			writer.write("Histogram Count" + separator +
-				statistic.getHistogramCount());
-		}
-		writer.newLine();
-
-		for (int bin = 0; bin < maxHistosLength; ++bin) {
-			firstTime = true;
-			for (int i = 0; i < histos.length; ++i) {
+		if(SLIMProcessor.macroParams.useDetailStat){///use detailed stat
+			for (final HistogramStatistics statistic : statistics) {
 				if (!firstTime) {
 					writer.write(separator);
 				}
 				firstTime = false;
-				if (bin < histos[i].length) {
-					writer.write("" + showParameter(centers[i][bin]) + separator +
-						histos[i][bin]);
-				}
-				else {
+				writer.write("Parameter" + separator + statistic.getTitle());
+				//writer.newLine();
+			}
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
 					writer.write(separator);
 				}
+				firstTime = false;
+				writer.write("Min" + separator + showParameter(statistic.getMin()));
 			}
 			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Max" + separator + showParameter(statistic.getMax()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Count" + separator + statistic.getCount());
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Mean" + separator + showParameter(statistic.getMean()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Standard Deviation" + separator +
+						showParameter(statistic.getStandardDeviation()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("1st Quartile" + separator +
+						showParameter(statistic.getFirstQuartile()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Median" + separator + showParameter(statistic.getMedian()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("3rd Quartile" + separator +
+						showParameter(statistic.getThirdQuartile()));
+			}
+			writer.newLine();
+
+			// get all of the histograms into memory
+			int maxHistosLength = Integer.MIN_VALUE;
+			final long[][] histos = new long[statistics.length][];
+			final double[][] centers = new double[statistics.length][];
+			for (int i = 0; i < statistics.length; ++i) {
+				histos[i] = statistics[i].getHistogram();
+				if (histos[i].length > maxHistosLength) {
+					maxHistosLength = histos[i].length;
+				}
+				centers[i] =
+						Binning.centerValuesPerBin(histos[i].length, statistics[i]
+								.getMinRange(), statistics[i].getMaxRange());
+			}
+
+			firstTime = true;
+			for (final long[] histo : histos) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Histogram Bins" + separator + histo.length);
+			}
+			writer.newLine();
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Histogram Min" + separator +
+						showParameter(statistic.getMinRange()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Histogram Max" + separator +
+						showParameter(statistic.getMaxRange()));
+			}
+			writer.newLine();
+
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write("Histogram Count" + separator +
+						statistic.getHistogramCount());
+			}
+			writer.newLine();
+
+			for (int bin = 0; bin < maxHistosLength; ++bin) {
+				firstTime = true;
+				for (int i = 0; i < histos.length; ++i) {
+					if (!firstTime) {
+						writer.write(separator);
+					}
+					firstTime = false;
+					if (bin < histos[i].length) {
+						writer.write("" + showParameter(centers[i][bin]) + separator +
+								histos[i][bin]);
+					}
+					else {
+						writer.write(separator);
+					}
+				}
+				writer.newLine();
+			}
+		}
+		else {/// for NOT detail stat
+			if(!SLIMProcessor.macroParams.writeParamOnce){
+				for (final HistogramStatistics statistic : statistics) {
+					if (!firstTime) {
+						writer.write(separator);
+					}
+					firstTime = false;//writing parameters
+					writer.write(statistic.getTitle());//title is A T Z X
+				}
+				SLIMProcessor.macroParams.writeParamOnce=true;
+			}
+			writer.newLine();
+			firstTime = true;
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;
+				writer.write( showParameter(statistic.getMean()));
+			}
+			writer.newLine();
+
 		}
 
 		return true;
+	}
+
+	/**
+	 * exports statistics only with mean values.
+	 * @param statistics
+	 * @param writer
+	 * @param separator
+	 * @param name
+	 * @return
+	 * @throws IOException
+	 */
+	public static boolean export(final HistogramStatistics[] statistics,
+			final BufferedWriter writer, final char separator,final String name) throws IOException{
+
+		boolean firstTime = true;
+		if(!SLIMProcessor.macroParams.writeParamOnce){
+			for (final HistogramStatistics statistic : statistics) {
+				if (!firstTime) {
+					writer.write(separator);
+				}
+				firstTime = false;//writing parameters
+				writer.write(statistic.getTitle());//title is A T Z X
+			}
+			SLIMProcessor.macroParams.writeParamOnce=true;
+		}
+		writer.newLine();
+		firstTime = true;
+		for (final HistogramStatistics statistic : statistics) {
+			if (!firstTime) {
+				writer.write(separator);
+			}
+			firstTime = false;
+			writer.write( showParameter(statistic.getMean()));
+		}
+		writer.write(separator+name);
+		return true;
+
+
 	}
 
 	private static String showParameter(final double parameter) {

--- a/src/main/java/loci/slim/analysis/HistogramStatistics.java
+++ b/src/main/java/loci/slim/analysis/HistogramStatistics.java
@@ -512,13 +512,14 @@ public class HistogramStatistics {
 				writer.newLine();
 			}
 		}
-		else {/// for NOT detail stat
+		else {/// for Brief stat, concise format
 			if(!SLIMProcessor.macroParams.writeParamOnce){
 				for (final HistogramStatistics statistic : statistics) {
 					if (!firstTime) {
 						writer.write(separator);
 					}
 					firstTime = false;//writing parameters
+					IJ.log("getting titles"+statistic.getTitle());
 					writer.write(statistic.getTitle());//title is A T Z X
 				}
 				SLIMProcessor.macroParams.writeParamOnce=true;
@@ -552,25 +553,34 @@ public class HistogramStatistics {
 			final BufferedWriter writer, final char separator,final String name) throws IOException{
 
 		boolean firstTime = true;
-		if(!SLIMProcessor.macroParams.writeParamOnce){
+		if(!SLIMProcessor.macroParams.isAppendUsed){///titles are not written when in append mode
 			for (final HistogramStatistics statistic : statistics) {
+
 				if (!firstTime) {
-					writer.write(separator);
+					writer.write(separator);		
 				}
 				firstTime = false;//writing parameters
-				writer.write(statistic.getTitle());//title is A T Z X
+					writer.write(statistic.getTitle());
 			}
-			SLIMProcessor.macroParams.writeParamOnce=true;
+			writer.newLine();
 		}
-		writer.newLine();
+		SLIMProcessor.macroParams.writeParamOnce=true;
+
+
 		firstTime = true;
+		SLIMProcessor.macroParams.meanStatValues= new String[statistics.length];
+		int i=0;
+
 		for (final HistogramStatistics statistic : statistics) {
 			if (!firstTime) {
 				writer.write(separator);
 			}
 			firstTime = false;
-			writer.write( showParameter(statistic.getMean()));
+			double meanVal=statistic.getMean();
+			SLIMProcessor.macroParams.meanStatValues[i++]=String.format("%.6f", meanVal);
+			writer.write( showParameter(meanVal));
 		}
+		SLIMProcessor.macroParams.fittingDone=true;
 		writer.write(separator+name);
 		return true;
 

--- a/src/main/java/loci/slim/analysis/plugins/ExportHistogramsToText.java
+++ b/src/main/java/loci/slim/analysis/plugins/ExportHistogramsToText.java
@@ -188,10 +188,11 @@ public class ExportHistogramsToText implements SLIMAnalyzer {
 		if (null != bufferedWriter) {
 			try {
 				// title this export
-				bufferedWriter.write("Export Histograms" + separator + image.getName());
-				bufferedWriter.newLine();
-				bufferedWriter.newLine();
-
+				if(SLIMProcessor.macroParams.useDetailStat){
+					bufferedWriter.write("Export Histograms" + separator + image.getName());
+					bufferedWriter.newLine();
+					bufferedWriter.newLine();
+				}
 				// look at image dimensions
 				final long[] dimensions = new long[image.numDimensions()];
 				image.dimensions(dimensions);
@@ -199,22 +200,32 @@ public class ExportHistogramsToText implements SLIMAnalyzer {
 
 				// for all channels
 				for (int channel = 0; channel < channels; ++channel) {
-					if (channels > 1) {
-						bufferedWriter.write("Channel" + separator + channel);
-						bufferedWriter.newLine();
-						bufferedWriter.newLine();
+					if(SLIMProcessor.macroParams.useDetailStat){
+						if (channels > 1) {
+							bufferedWriter.write("Channel" + separator + channel);
+							bufferedWriter.newLine();
+							bufferedWriter.newLine();
+						}
 					}
-
+					if(!SLIMProcessor.macroParams.useDetailStat & channel>0){continue;}//one channel if use brief stat
+					IJ.log("Channel "+Integer.toString(channel));
 					final HistogramStatistics[] statisticsArray =
 						new HistogramStatistics[fittedValues.length];
 					for (int i = 0; i < fittedValues.length; ++i) {
 						statisticsArray[i] =
 							getStatistics(image, channel, params, fittedValues[i]);
 					}
-
+					IJ.log("channels "+channels);
+					IJ.log("dim "+Integer.toString((int)dimensions[1]));
 					if (combined) {
-						HistogramStatistics.export(statisticsArray, bufferedWriter,
-							separator);
+						if(SLIMProcessor.macroParams.useDetailStat){
+							HistogramStatistics.export(statisticsArray, bufferedWriter,
+									separator);
+						}
+						else{
+							HistogramStatistics.export(statisticsArray, bufferedWriter,
+									separator,image.getName());
+						}
 					}
 					else {
 						for (final HistogramStatistics statistics : statisticsArray) {

--- a/src/main/java/loci/slim/analysis/plugins/ExportHistogramsToText.java
+++ b/src/main/java/loci/slim/analysis/plugins/ExportHistogramsToText.java
@@ -208,15 +208,15 @@ public class ExportHistogramsToText implements SLIMAnalyzer {
 						}
 					}
 					if(!SLIMProcessor.macroParams.useDetailStat & channel>0){continue;}//one channel if use brief stat
-					IJ.log("Channel "+Integer.toString(channel));
+					//IJ.log("Channel "+Integer.toString(channel));
 					final HistogramStatistics[] statisticsArray =
 						new HistogramStatistics[fittedValues.length];
 					for (int i = 0; i < fittedValues.length; ++i) {
 						statisticsArray[i] =
 							getStatistics(image, channel, params, fittedValues[i]);
 					}
-					IJ.log("channels "+channels);
-					IJ.log("dim "+Integer.toString((int)dimensions[1]));
+					//IJ.log("channels "+channels);
+					//IJ.log("dim "+Integer.toString((int)dimensions[1]));
 					if (combined) {
 						if(SLIMProcessor.macroParams.useDetailStat){
 							HistogramStatistics.export(statisticsArray, bufferedWriter,
@@ -562,6 +562,7 @@ public class ExportHistogramsToText implements SLIMAnalyzer {
 		}
 		fileName = dialog.getNextString();
 		append = dialog.getNextBoolean();
+		SLIMProcessor.macroParams.isAppendUsed=append;//recod append mode so that when we append in brief mode, it does not add titles
 		csv = dialog.getNextBoolean();
 
 		if (append) {

--- a/src/main/java/loci/slim/paramSetMacro.java
+++ b/src/main/java/loci/slim/paramSetMacro.java
@@ -135,13 +135,14 @@ public class paramSetMacro {
 	public boolean isExcitationChanging = false;
 	//macro for exporting histogram
 	public static boolean writeParamOnce=false;
-	public static final boolean useDetailStat=false;//boolean for exporting detail statistics
-
+	public static boolean useDetailStat=false;//boolean for exporting detail statistics
+	public static boolean isAppendSet=false;
 	// variables for starting SLIM with macro
 	public boolean startSLIMCurveWithMacro = false;
 	public String startPathName = null;
 	public String startFileName = null;
-
+	public String[] meanStatValues; 
+	public boolean fittingDone=false;
 	// //append
 	public boolean isAppendUsed = false;
 	public boolean isAppendUsedPixel = false;

--- a/src/main/java/loci/slim/paramSetMacro.java
+++ b/src/main/java/loci/slim/paramSetMacro.java
@@ -133,6 +133,9 @@ public class paramSetMacro {
 	public String exportHistoFileNameSingleFileSeperatorSLIM2 = null;
 
 	public boolean isExcitationChanging = false;
+	//macro for exporting histogram
+	public static boolean writeParamOnce=false;
+	public static final boolean useDetailStat=false;//boolean for exporting detail statistics
 
 	// variables for starting SLIM with macro
 	public boolean startSLIMCurveWithMacro = false;


### PR DESCRIPTION
This branch has the changes concise mean lifetime value display. It writes the mean lifetime values in a concise format in external files, also shows them in a dropdown menu in SLIM plugin